### PR TITLE
Adds dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This adds support for dependbot to update submodules as they're modified upstream.

@zotoli As the repo Admin you will need to enable dependabot through github by going to *Insights > Dependency graph > Dependabot > Enable* 

After this is done, the PR can be merged.
